### PR TITLE
fix: prevent recursion

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -44,7 +44,7 @@ import {
   newFluxNode,
   appendTextToFluxNodeAsGPT,
   getFluxNodeLineage,
-  getFluxNodeLineageIndex,
+  isFluxNodeInLineage,
   addFluxNode,
   modifyFluxNode,
   getFluxNodeChildren,
@@ -161,8 +161,14 @@ function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const onConnect = (connection: Edge<any> | Connection) => {
-    // Check the lineage of the source node to make sure we are not creating a recursive connection
-    if(getFluxNodeLineageIndex(nodes, edges, connection.source!, connection.target!) != undefined)
+    // Check the lineage of the source node to make
+    // sure we aren't creating a recursive connection.
+    if (
+      isFluxNodeInLineage(nodes, edges, {
+        nodeToCheck: connection.target!,
+        nodeToGetLineageOf: connection.source!,
+      })
+    )
       return;
 
     takeSnapshot();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -160,6 +160,10 @@ function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const onConnect = (connection: Edge<any> | Connection) => {
+    // Check the lineage of the source node to make sure we are not creating a recursive loop
+    const lineage = getFluxNodeLineage(nodes, edges, connection.source!);
+    if(lineage.some(node => node.id == connection.target!)) return;
+    
     takeSnapshot();
     setEdges((eds) => addEdge({ ...connection }, eds));
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -44,6 +44,7 @@ import {
   newFluxNode,
   appendTextToFluxNodeAsGPT,
   getFluxNodeLineage,
+  getFluxNodeLineageIndex,
   addFluxNode,
   modifyFluxNode,
   getFluxNodeChildren,
@@ -160,10 +161,10 @@ function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const onConnect = (connection: Edge<any> | Connection) => {
-    // Check the lineage of the source node to make sure we are not creating a recursive loop
-    const lineage = getFluxNodeLineage(nodes, edges, connection.source!);
-    if(lineage.some(node => node.id == connection.target!)) return;
-    
+    // Check the lineage of the source node to make sure we are not creating a recursive connection
+    if(getFluxNodeLineageIndex(nodes, edges, connection.source!, connection.target!) != undefined)
+      return;
+
     takeSnapshot();
     setEdges((eds) => addEdge({ ...connection }, eds));
   };

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -289,7 +289,7 @@ export function getFluxNodeLineageIndex(
   let currentId: string | undefined = childId;
 
   while (currentId !== undefined) {
-    if(currentId == parentId) return index;
+    if (currentId == parentId) return index;
 
     currentId = getFluxNodeParent(existingNodes, existingEdges, currentId)?.id;
 

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -275,28 +275,14 @@ export function getFluxNodeLineage(
   return lineage;
 }
 
-// Get the index of the parent node in the lineage of the child
-// where index 0 is the node,
-// index 1 is the node's parent,
-// index 2 is the node's grandparent, etc.
-export function getFluxNodeLineageIndex(
+export function isFluxNodeInLineage(
   existingNodes: Node<FluxNodeData>[],
   existingEdges: Edge[],
-  childId: string,
-  parentId: string
-): number | undefined {
-  let index = 0;
-  let currentId: string | undefined = childId;
+  { nodeToCheck, nodeToGetLineageOf }: { nodeToCheck: string; nodeToGetLineageOf: string }
+): boolean {
+  const lineage = getFluxNodeLineage(existingNodes, existingEdges, nodeToGetLineageOf);
 
-  while (currentId !== undefined) {
-    if (currentId == parentId) return index;
-
-    currentId = getFluxNodeParent(existingNodes, existingEdges, currentId)?.id;
-
-    index++;
-  }
-
-  return undefined;
+  return lineage.some((node) => node.id === nodeToCheck);
 }
 
 /*//////////////////////////////////////////////////////////////

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -279,8 +279,6 @@ export function getFluxNodeLineage(
 // where index 0 is the node,
 // index 1 is the node's parent,
 // index 2 is the node's grandparent, etc.
-// TODO: Eventually would be nice to have
-// support for connecting multiple parents!
 export function getFluxNodeLineageIndex(
   existingNodes: Node<FluxNodeData>[],
   existingEdges: Edge[],

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -275,6 +275,32 @@ export function getFluxNodeLineage(
   return lineage;
 }
 
+// Get the index of the parent node in the lineage of the child
+// where index 0 is the node,
+// index 1 is the node's parent,
+// index 2 is the node's grandparent, etc.
+// TODO: Eventually would be nice to have
+// support for connecting multiple parents!
+export function getFluxNodeLineageIndex(
+  existingNodes: Node<FluxNodeData>[],
+  existingEdges: Edge[],
+  childId: string,
+  parentId: string
+): number | undefined {
+  let index = 0;
+  let currentId: string | undefined = childId;
+
+  while (currentId !== undefined) {
+    if(currentId == parentId) return index;
+
+    currentId = getFluxNodeParent(existingNodes, existingEdges, currentId)?.id;
+
+    index++;
+  }
+
+  return undefined;
+}
+
 /*//////////////////////////////////////////////////////////////
                             RENDERERS
 //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
This makes it so connecting a node to its parent (or grandparent etc.) isn't possible