### PR TITLE
feat: Added NumberInput to LabeledSlider

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -187,6 +187,7 @@ export function Prompt({
             max={1.25}
             min={0}
             step={0.01}
+            precision={2}
           />
 
           <LabeledSlider
@@ -198,6 +199,7 @@ export function Prompt({
             max={10}
             min={1}
             step={1}
+            precision={0}
           />
         </>
       ) : null}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -85,6 +85,7 @@ export const SettingsModal = React.memo(function SettingsModal({
             max={1.25}
             min={0}
             step={0.01}
+            precision={2}
           />
 
           <LabeledSlider
@@ -96,6 +97,7 @@ export const SettingsModal = React.memo(function SettingsModal({
             max={10}
             min={1}
             step={1}
+            precision={0}
           />
 
           <Checkbox

--- a/src/components/utils/LabeledInputs.tsx
+++ b/src/components/utils/LabeledInputs.tsx
@@ -44,11 +44,56 @@ export function LabeledSlider({
   step: number;
   precision: number;
 } & BoxProps) {
+
+  // Keep state for inputs that are invalid (being typed)
+  const [incompleteInput, setIncompleteInput] = useState(false);
+  const [inputStr, setInputStr] = useState("");
+  const [defaultValue, setDefaultValue] = useState(value);
+
+  // Handle input changes and update state accordingly
+  const inputChangeHandler = (s: string, v: number) => {
+    const isDecimalNotAllowed = precision === 0 && /\./.test(s);
+    const isIncompleteInput = s === "" || (!isDecimalNotAllowed && /^\d+\.$/.test(s));
+    
+    setIncompleteInput(isIncompleteInput);
+    setInputStr(s);
+  
+    if (!isIncompleteInput && !isDecimalNotAllowed) {
+      setValue(isNaN(v) ? defaultValue : v);
+    }
+  };
+
+  // Reset values to default if input is empty onBlur
+  const handleBlur = (event?: React.FocusEvent<HTMLInputElement>) => {
+    if (inputStr === "") {
+      setIncompleteInput(false);
+      setValue(defaultValue);
+    }
+  };
+
+  // Reset value binding if input is invalid on slider click
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (incompleteInput) {
+      setIncompleteInput(false);
+    }
+  };
+
   return (
     <Box {...others}>
       <Flex {...others} alignItems="center">
         <b>{label}:</b> 
-        <NumberInput size='xs' maxW='100px' ml='0.5rem' step={step} max={max} min={min} value={value} precision={precision} onChange={(_, v) => setValue(isNaN(v) ? min : v)}>
+        <NumberInput 
+          size='xs' 
+          maxW='75px' 
+          ml='0.5rem' 
+          step={step} 
+          max={max} 
+          min={min} 
+          precision={precision} 
+          value={incompleteInput ? inputStr : value}
+          onChange={inputChangeHandler}
+          onBlur={handleBlur}
+        >
           <NumberInputField />
           <NumberInputStepper>
             <NumberIncrementStepper />
@@ -65,6 +110,7 @@ export function LabeledSlider({
         min={min}
         step={step}
         focusThumbOnChange={false}
+        onClick={handleClick}
       >
         <SliderTrack>
           <SliderFilledTrack bg={color} />

--- a/src/components/utils/LabeledInputs.tsx
+++ b/src/components/utils/LabeledInputs.tsx
@@ -4,10 +4,16 @@ import {
   Box,
   BoxProps,
   Button,
+  Flex,
   Input,
   InputGroup,
   InputRightElement,
   Link,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
   Select,
   Slider,
   SliderFilledTrack,
@@ -26,6 +32,7 @@ export function LabeledSlider({
   max,
   min,
   step,
+  precision,
   ...others
 }: {
   label: string;
@@ -35,10 +42,20 @@ export function LabeledSlider({
   max: number;
   min: number;
   step: number;
+  precision: number;
 } & BoxProps) {
   return (
     <Box {...others}>
-      <b>{label}:</b> {value}
+      <Flex {...others} alignItems="center">
+        <b>{label}:</b> 
+        <NumberInput size='xs' maxW='100px' ml='0.5rem' step={step} max={max} min={min} value={value} precision={precision} onChange={(_, v) => setValue(isNaN(v) ? min : v)}>
+          <NumberInputField />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+        </NumberInput>
+      </Flex>
       <Slider
         mx="2px"
         aria-label="temp-slider"
@@ -47,6 +64,7 @@ export function LabeledSlider({
         max={max}
         min={min}
         step={step}
+        focusThumbOnChange={false}
       >
         <SliderTrack>
           <SliderFilledTrack bg={color} />


### PR DESCRIPTION
Thanks T11 and Paradigm team for putting this together, super cool.

I thought the slider component could be improved if it allowed users to put values into an input box. I made use of [ChakraUI's NumberInput](https://chakra-ui.com/docs/components/number-input). The validation took a little bit of work since their component works best when the value is a string. Nevertheless, I think I have a decent solution.

No worries if this feature isn't needed or introduces unneeded complexity. Happy to make changes if others see a better way to implement as well.

If this were to be merged it might be better to change the component name to something like InputSlider to be more representative of the new layout.
![Screenshot 2023-03-29 at 1 55 17 AM](https://user-images.githubusercontent.com/8097617/228450898-caa44b88-2007-4647-85a0-3859b2843574.png)