### PR TITLE
feat: a stop generating button

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -1,17 +1,17 @@
-import { Node } from "reactflow";
+import { Node, useReactFlow } from "reactflow";
 
 import { useState, useEffect, useRef } from "react";
 
 import { Spinner, Text, Button } from "@chakra-ui/react";
 
-import { EditIcon, ViewIcon, CloseIcon } from "@chakra-ui/icons";
+import { EditIcon, ViewIcon, NotAllowedIcon } from "@chakra-ui/icons";
 
 import TextareaAutosize from "react-textarea-autosize";
 
+import { displayNameFromFluxNodeType, setFluxNodeStreamId } from "../utils/fluxNode";
 import { getFluxNodeTypeColor, getFluxNodeTypeDarkColor } from "../utils/color";
-import { TextAndCodeBlock } from "./utils/TextAndCodeBlock";
 import { FluxNodeData, FluxNodeType, Settings } from "../utils/types";
-import { displayNameFromFluxNodeType } from "../utils/fluxNode";
+import { TextAndCodeBlock } from "./utils/TextAndCodeBlock";
 import { LabeledSlider } from "./utils/LabeledInputs";
 import { Row, Center, Column } from "../utils/chakra";
 import { BigButton } from "./utils/BigButton";
@@ -35,6 +35,8 @@ export function Prompt({
   settings: Settings;
   setSettings: (settings: Settings) => void;
 }) {
+  const { setNodes } = useReactFlow();
+
   const promptNode = lineage[0];
 
   const promptNodeType = promptNode.data.fluxNodeType;
@@ -48,7 +50,10 @@ export function Prompt({
   };
 
   const stopGenerating = () => {
-    // TODO
+    // Reset the stream id.
+    setNodes((nodes) =>
+      setFluxNodeStreamId(nodes, { id: promptNode.id, streamId: undefined })
+    );
   };
 
   /*//////////////////////////////////////////////////////////////
@@ -129,25 +134,26 @@ export function Prompt({
               onMouseLeave={() => setHoveredNodeId(null)}
               bg={getFluxNodeTypeColor(data.fluxNodeType)}
               key={node.id}
-              onClick={
-                isLast
-                  ? isEditing
-                    ? undefined
-                    : () => setIsEditing(true)
-                  : () => {
-                      const selection = window.getSelection();
+              onClick={() => {
+                const selection = window.getSelection();
 
-                      // We don't want to trigger the selection
-                      // if they're just selecting/copying text.
-                      if (selection?.isCollapsed) {
-                        // TODO: Note this is basically broken because of codeblocks.
-                        textOffsetRef.current = selection.anchorOffset ?? 0;
+                // We don't want to trigger the selection
+                // if they're just selecting/copying text.
+                if (selection?.isCollapsed) {
+                  if (isLast) {
+                    if (data.streamId) {
+                      stopGenerating();
+                      setIsEditing(true);
+                    } else if (!isEditing) setIsEditing(true);
+                  } else {
+                    // TODO: Note this is basically broken because of codeblocks.
+                    textOffsetRef.current = selection.anchorOffset ?? 0;
 
-                        selectNode(node.id);
-                        setIsEditing(true);
-                      }
-                    }
-              }
+                    selectNode(node.id);
+                    setIsEditing(true);
+                  }
+                }
+              }}
               cursor={isLast && isEditing ? "text" : "pointer"}
             >
               {data.streamId && data.text === "" ? (
@@ -163,7 +169,7 @@ export function Prompt({
                         : "none"
                     }
                     onClick={() =>
-                      data.generating ? stopGenerating() : setIsEditing(!isEditing)
+                      data.streamId ? stopGenerating() : setIsEditing(!isEditing)
                     }
                     position="absolute"
                     top={1}
@@ -174,8 +180,8 @@ export function Prompt({
                     _hover={{ background: "none" }}
                     p={1}
                   >
-                    {data.generating ? (
-                      <CloseIcon boxSize={4} />
+                    {data.streamId ? (
+                      <NotAllowedIcon boxSize={4} />
                     ) : isEditing ? (
                       <ViewIcon boxSize={4} />
                     ) : (

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 
 import { Spinner, Text, Button } from "@chakra-ui/react";
 
-import { EditIcon, ViewIcon } from "@chakra-ui/icons";
+import { EditIcon, ViewIcon, CloseIcon } from "@chakra-ui/icons";
 
 import TextareaAutosize from "react-textarea-autosize";
 
@@ -45,6 +45,10 @@ export function Prompt({
     } else {
       newConnectedToSelectedNode(FluxNodeType.User);
     }
+  };
+
+  const stopGenerating = () => {
+    // TODO
   };
 
   /*//////////////////////////////////////////////////////////////
@@ -156,7 +160,9 @@ export function Prompt({
                         ? "block"
                         : "none"
                     }
-                    onClick={() => setIsEditing(!isEditing)}
+                    onClick={() =>
+                      data.generating ? stopGenerating() : setIsEditing(!isEditing)
+                    }
                     position="absolute"
                     top={1}
                     right={1}
@@ -166,7 +172,13 @@ export function Prompt({
                     _hover={{ background: "none" }}
                     p={1}
                   >
-                    {isEditing ? <ViewIcon boxSize={4} /> : <EditIcon boxSize={4} />}
+                    {data.generating ? (
+                      <CloseIcon boxSize={4} />
+                    ) : isEditing ? (
+                      <ViewIcon boxSize={4} />
+                    ) : (
+                      <EditIcon boxSize={4} />
+                    )}
                   </Button>
                   <Text fontWeight="bold" width="auto" whiteSpace="nowrap">
                     {displayNameFromFluxNodeType(data.fluxNodeType)}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -57,3 +57,6 @@ export const NEW_TREE_X_OFFSET = 600;
 export const CODE_BLOCK_DETECT_REGEX =
   /\s*(```(?:[a-zA-Z0-9-]*\n|\n?)([\s\S]+?)\n```)\s*/;
 export const CODE_BLOCK_LANGUAGE_DETECT_REGEX = /^```[a-zA-Z0-9-]*$/m;
+
+export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
+export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -1,6 +1,11 @@
 import { Node, Edge } from "reactflow";
 
-import { NEW_TREE_X_OFFSET, OVERLAP_RANDOMNESS_MAX } from "./constants";
+import {
+  NEW_TREE_X_OFFSET,
+  OVERLAP_RANDOMNESS_MAX,
+  STALE_STREAM_ERROR_MESSAGE,
+  STREAM_CANCELED_ERROR_MESSAGE,
+} from "./constants";
 import { FluxNodeType, FluxNodeData, ReactFlowNodeTypes } from "./types";
 import { getFluxNodeTypeColor } from "./color";
 import { generateNodeId } from "./nodeId";
@@ -183,10 +188,12 @@ export function appendTextToFluxNodeAsGPT(
   return existingNodes.map((node) => {
     if (node.id !== id) return node;
 
-    // If the node's streamId does not match the one
-    // passed, we're appending text from a stale stream.
-    // Throw to alert the caller they should abort the stream.
-    if (node.data.streamId !== streamId) throw new Error("STALE_STREAM_ID");
+    // If the node's streamId is now undefined, the stream has been canceled.
+    if (node.data.streamId === undefined) throw new Error(STREAM_CANCELED_ERROR_MESSAGE);
+
+    // If the node's streamId is not undefined but does
+    // not match the provided id, the stream is now stale.
+    if (node.data.streamId !== streamId) throw new Error(STALE_STREAM_ERROR_MESSAGE);
 
     const copy = { ...node, data: { ...node.data } };
 


### PR DESCRIPTION
# WIP

Currently blocked on a robust system to cancel generations like @Hey has done here https://github.com/Hey/flux/commits/fix/gibberish-edit 

## Motivation

https://github.com/transmissions11/flux/issues/16

## Solution

use the fact that GPT nodes are now in "view" mode by default to block editing and add a new button its place to pause generation 