### PR TITLE
feat/fix: track and abort stale streams

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -429,6 +429,7 @@ function App() {
           // If the choice has a finish reason, then it's the final
           // choice and we can mark it as no longer animated right now.
           if (choice.finish_reason !== null) {
+            // Reset the stream id.
             setNodes((nodes) =>
               setFluxNodeStreamId(nodes, { id: correspondingNodeId, streamId: undefined })
             );
@@ -588,7 +589,7 @@ function App() {
 
       // If the stream wasn't forcibly canceled.
       if (!abortController.signal.aborted)
-        // Reset the streamId.
+        // Reset the stream id.
         setNodes((nodes) =>
           setFluxNodeStreamId(nodes, { id: selectedNodeId, streamId: undefined })
         );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -377,9 +377,11 @@ function App() {
                   id: correspondingNodeId,
                   text: choice.delta?.content ?? UNDEFINED_RESPONSE_STRING,
                 });
-              // If the stream ID does not match, it is stale and we ignore.
+              // If the stream ID does not match, it is stale and we should cancel it.
               } else {
-                // console.log(`Skipping update for node ${correspondingNodeId} because ${thisStreamId} !== ${currentNodeStreamId}`);
+                // console.log(`Cancelling stream for node ${correspondingNodeId} because ${thisStreamId} doesn't match ${currentNodeStreamId}`);
+                
+                if (!stream.locked) stream.cancel()
                 return newerNodes;
               }
             });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -56,8 +56,8 @@ import {
   deleteFluxNode,
   deleteSelectedFluxNodes,
   addUserNodeLinkedToASystemNode,
-  markFluxNodeAsDoneGenerating,
   getConnectionAllowed,
+  setFluxNodeStreamId,
 } from "../utils/fluxNode";
 import {
   FluxNodeData,
@@ -85,13 +85,13 @@ import { mod } from "../utils/mod";
 import { BigButton } from "./utils/BigButton";
 import { Column, Row } from "../utils/chakra";
 import { isValidAPIKey } from "../utils/apikey";
-import { generateNodeId } from "../utils/nodeId";
 import { useLocalStorage } from "../utils/lstore";
 import { NavigationBar } from "./utils/NavigationBar";
 import { useDebouncedEffect } from "../utils/debounce";
 import { useDebouncedWindowResize } from "../utils/resize";
 import { getQueryParam, resetURL } from "../utils/qparams";
 import { copySnippetToClipboard } from "../utils/clipboard";
+import { generateNodeId, generateStreamId } from "../utils/nodeId";
 import { messagesFromLineage, promptFromLineage } from "../utils/prompt";
 import { newFluxEdge, modifyFluxEdge, addFluxEdge } from "../utils/fluxEdge";
 import { getFluxNodeTypeColor, getFluxNodeTypeDarkColor } from "../utils/color";
@@ -295,7 +295,7 @@ function App() {
     const currentNode = getFluxNode(newNodes, parentNodeId)!;
     const currentNodeChildren = getFluxNodeGPTChildren(newNodes, edges, parentNodeId);
 
-    const thisStreamId = generateNodeId()
+    const streamId = generateStreamId();
 
     let firstCompletionId: string | undefined;
 
@@ -317,8 +317,7 @@ function App() {
             text: "",
             label: displayNameFromFluxNodeType(FluxNodeType.GPT),
             fluxNodeType: FluxNodeType.GPT,
-            generating: true,
-            streamId: thisStreamId,
+            streamId,
           },
           style: {
             ...childNode.style,
@@ -327,8 +326,6 @@ function App() {
         };
       } else {
         const id = generateNodeId();
-
-        console.log("Generated new node id: " + id)
 
         if (i === 0) firstCompletionId = id;
 
@@ -356,8 +353,7 @@ function App() {
             y: currentNode.position.y + 100 + Math.random() * OVERLAP_RANDOMNESS_MAX,
             fluxNodeType: FluxNodeType.GPT,
             text: "",
-            generating: true,
-            streamId: thisStreamId,
+            streamId,
           })
         );
       }
@@ -381,10 +377,8 @@ function App() {
 
       const abortController = new AbortController();
 
-      let streamCancelled = false;
-
       for await (const chunk of yieldStream(stream, abortController)) {
-        if (streamCancelled) break;
+        if (abortController.signal.aborted) break;
 
         try {
           const decoded = JSON.parse(DECODER.decode(chunk));
@@ -412,19 +406,15 @@ function App() {
           // choice with only a role delta and no content.
           if (choice.delta?.content) {
             setNodes((newerNodes) => {
-              const currentNodeStreamId = getFluxNode(newerNodes, correspondingNodeId)?.data.streamId;
-              // console.log(`Received stream for node ${correspondingNodeId} with stream ID ${currentNodeStreamId} and this stream ID ${thisStreamId}`);
-
-              if (currentNodeStreamId === thisStreamId) {
+              try {
                 return appendTextToFluxNodeAsGPT(newerNodes, {
                   id: correspondingNodeId,
                   text: choice.delta?.content ?? UNDEFINED_RESPONSE_STRING,
+                  streamId, // This will cause a throw if the streamId has changed.
                 });
-                // If the stream ID does not match, it is stale and we should cancel it.
-              } else {
-                console.log(`Cancelling stream for node ${correspondingNodeId} because ${thisStreamId} doesn't match ${currentNodeStreamId}`);
-
-                streamCancelled = true
+              } catch (e) {
+                // If the stream id does not match,
+                // it is stale and we should abort.
                 abortController.abort();
 
                 return newerNodes;
@@ -432,18 +422,16 @@ function App() {
             });
           }
 
-          // We cannot return within the loop, and we do not want to execute the code below. So we break.
-          // It is possible to do modify the if statement below to check for streamCancelled, but if we add
-          // more code other than the choice.finish_reason check, it might be forgotten and this is more explicit.
-          if (streamCancelled) {
-            // console.log(`Left the stream loop for node ${correspondingNodeId}, now breaking because stream was cancelled`);
-            break;
-          }
+          // We cannot return within the loop, and we do
+          // not want to execute the code below, so we break.
+          if (abortController.signal.aborted) break;
 
           // If the choice has a finish reason, then it's the final
           // choice and we can mark it as no longer animated right now.
           if (choice.finish_reason !== null) {
-            setNodes((nodes) => markFluxNodeAsDoneGenerating(nodes, correspondingNodeId));
+            setNodes((nodes) =>
+              setFluxNodeStreamId(nodes, { id: correspondingNodeId, streamId: undefined })
+            );
 
             setEdges((edges) =>
               modifyFluxEdge(edges, {
@@ -458,22 +446,27 @@ function App() {
         }
       }
 
-      // Mark all the edges as no longer animated.
-      for (let i = 0; i < responses; i++) {
-        const correspondingNodeId =
-          overrideExistingIfPossible && i < currentNodeChildren.length
-            ? currentNodeChildren[i].id
-            : newNodes[newNodes.length - responses + i].id;
+      // If the stream wasn't forcibly canceled.
+      if (!abortController.signal.aborted) {
+        // Mark all the edges as no longer animated.
+        for (let i = 0; i < responses; i++) {
+          const correspondingNodeId =
+            overrideExistingIfPossible && i < currentNodeChildren.length
+              ? currentNodeChildren[i].id
+              : newNodes[newNodes.length - responses + i].id;
 
-        setNodes((nodes) => markFluxNodeAsDoneGenerating(nodes, correspondingNodeId));
+          setNodes((nodes) =>
+            setFluxNodeStreamId(nodes, { id: correspondingNodeId, streamId: undefined })
+          );
 
-        setEdges((edges) =>
-          modifyFluxEdge(edges, {
-            source: parentNodeId,
-            target: correspondingNodeId,
-            animated: false,
-          })
-        );
+          setEdges((edges) =>
+            modifyFluxEdge(edges, {
+              source: parentNodeId,
+              target: correspondingNodeId,
+              animated: false,
+            })
+          );
+        }
       }
     })().catch((err) =>
       toast({
@@ -532,27 +525,37 @@ function App() {
 
     const temp = settings.temp;
 
-    const parentNodeLineage = selectedNodeLineage;
-    const parentNodeId = parentNodeLineage[0].id;
+    const lineage = selectedNodeLineage;
+    const selectedNodeId = lineage[0].id;
+
+    const streamId = generateStreamId();
+
+    // Set the node's streamId to it will accept the incoming text.
+    setNodes((nodes) => setFluxNodeStreamId(nodes, { id: selectedNodeId, streamId }));
 
     (async () => {
-      // TODO: Stop sequences for user/assistant/etc? min tokens?
-      // Select between instruction and auto completer?
+      // TODO: Stop sequences for user/assistant/etc?
+      // TODO: Select between instruction and auto raw base models?
       const stream = await OpenAI(
         "completions",
         {
-          model: "text-davinci-003", // TODO: Allow customizing.
-          temperature: temp, // TODO: Allow customizing.
-          prompt: promptFromLineage(parentNodeLineage, settings),
-          max_tokens: 250, // Allow customizing.
-          stop: ["\n\n", "assistant:", "user:"], // TODO: Allow customizing.
+          // TODO: Allow customizing.
+          model: "text-davinci-003",
+          temperature: temp,
+          prompt: promptFromLineage(lineage, settings),
+          max_tokens: 250,
+          stop: ["\n\n", "assistant:", "user:"],
         },
         { apiKey: apiKey!, mode: "raw" }
       );
 
       const DECODER = new TextDecoder();
 
-      for await (const chunk of yieldStream(stream)) {
+      const abortController = new AbortController();
+
+      for await (const chunk of yieldStream(stream, abortController)) {
+        if (abortController.signal.aborted) break;
+
         try {
           const decoded = JSON.parse(DECODER.decode(chunk));
 
@@ -563,16 +566,32 @@ function App() {
 
           const choice: CreateCompletionResponseChoicesInner = decoded.choices[0];
 
-          setNodes((newNodes) =>
-            appendTextToFluxNodeAsGPT(newNodes, {
-              id: parentNodeId,
-              text: choice.text ?? UNDEFINED_RESPONSE_STRING,
-            })
-          );
+          setNodes((newerNodes) => {
+            try {
+              return appendTextToFluxNodeAsGPT(newerNodes, {
+                id: selectedNodeId,
+                text: choice.text ?? UNDEFINED_RESPONSE_STRING,
+                streamId, // This will cause a throw if the streamId has changed.
+              });
+            } catch (e) {
+              // If the stream id does not match,
+              // it is stale and we should abort.
+              abortController.abort();
+
+              return newerNodes;
+            }
+          });
         } catch (err) {
           console.error(err);
         }
       }
+
+      // If the stream wasn't forcibly canceled.
+      if (!abortController.signal.aborted)
+        // Reset the streamId.
+        setNodes((nodes) =>
+          setFluxNodeStreamId(nodes, { id: selectedNodeId, streamId: undefined })
+        );
     })().catch((err) => console.error(err));
   };
 
@@ -646,7 +665,6 @@ function App() {
           y: selectedNode.position.y + 100 + Math.random() * OVERLAP_RANDOMNESS_MAX,
           fluxNodeType: type,
           text: "",
-          generating: false
         })
       );
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -530,7 +530,7 @@ function App() {
 
     const streamId = generateStreamId();
 
-    // Set the node's streamId to it will accept the incoming text.
+    // Set the node's streamId so it will accept the incoming text.
     setNodes((nodes) => setFluxNodeStreamId(nodes, { id: selectedNodeId, streamId }));
 
     (async () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -325,8 +325,6 @@ function App() {
 
     if (firstCompletionId === undefined) throw new Error("No first completion id!");
 
-    // setNodes((newerNodes) => setStreamIdToFluxNode(newerNodes, { id: firstCompletionId || 'completion-id', streamId: thisStreamId || 'new' }));
-
     (async () => {
       const stream = await OpenAI(
         "chat",

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -146,7 +146,7 @@ export function Prompt({
               }
               cursor={isLast && isEditing ? "text" : "pointer"}
             >
-              {data.generating && data.text === "" ? (
+              {data.streamId && data.text === "" ? (
                 <Center expand>
                   <Spinner />
                 </Center>

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -16,6 +16,7 @@ export function newFluxNode({
   fluxNodeType,
   text,
   generating,
+  streamId,
 }: {
   id?: string;
   x: number;
@@ -23,6 +24,7 @@ export function newFluxNode({
   fluxNodeType: FluxNodeType;
   text: string;
   generating: boolean;
+  streamId?: string
 }): Node<FluxNodeData> {
   return {
     id: id ?? generateNodeId(),
@@ -35,6 +37,7 @@ export function newFluxNode({
       fluxNodeType,
       text,
       generating,
+      streamId
     },
   };
 }
@@ -52,6 +55,7 @@ export function addFluxNode(
     fluxNodeType,
     text,
     generating,
+    streamId
   }: {
     id?: string;
     x: number;
@@ -59,9 +63,10 @@ export function addFluxNode(
     fluxNodeType: FluxNodeType;
     text: string;
     generating: boolean;
+    streamId?: string
   }
 ): Node<FluxNodeData>[] {
-  const newNode = newFluxNode({ x, y, fluxNodeType, text, id, generating });
+  const newNode = newFluxNode({ x, y, fluxNodeType, text, id, generating, streamId: 'newStream' });
 
   return [...existingNodes, newNode];
 }

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -66,7 +66,7 @@ export function addFluxNode(
     streamId?: string
   }
 ): Node<FluxNodeData>[] {
-  const newNode = newFluxNode({ x, y, fluxNodeType, text, id, generating, streamId: 'newStream' });
+  const newNode = newFluxNode({ x, y, fluxNodeType, text, id, generating, streamId: '' });
 
   return [...existingNodes, newNode];
 }

--- a/src/utils/nodeId.ts
+++ b/src/utils/nodeId.ts
@@ -1,3 +1,3 @@
-export function generateNodeId() {
+export function generateNodeId(): string {
   return Math.random().toString().replace("0.", "");
 }

--- a/src/utils/nodeId.ts
+++ b/src/utils/nodeId.ts
@@ -1,3 +1,7 @@
 export function generateNodeId(): string {
   return Math.random().toString().replace("0.", "");
 }
+
+export function generateStreamId(): string {
+  return Math.random().toString().replace("0.", "");
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,6 +6,7 @@ export type FluxNodeData = {
   fluxNodeType: FluxNodeType;
   text: string;
   generating: boolean;
+  streamId?: string;
 };
 
 export enum FluxNodeType {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,7 +6,6 @@ export type FluxNodeData = {
   label: string;
   fluxNodeType: FluxNodeType;
   text: string;
-  generating: boolean;
   streamId?: string;
 };
 


### PR DESCRIPTION
## Motivation

Fixes #22 

This handles the case where a user regenerates by editing the prompt or temperature, or just regenerating, a currently running stream which causes both streams to mix into the same node text causing gibberish output.

## Solution

We update the stream id of a node each time there is a new update to a node, and in our running stream receiver we check if the current stream id from the running stream is the same as the newest stream in our global node state, and if it's different we cancel the stream and we break out of the loop and ignore the results.
