### PR TITLE
fix: rename bugs

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -880,12 +880,12 @@ function App() {
   //////////////////////////////////////////////////////////////*/
 
   const showRenameInput = () => {
-    takeSnapshot();
-
     const selectedNode = nodes.find((node) => node.selected);
     const nodeId = selectedNode?.id ?? selectedNodeId;
 
     if (nodeId) {
+      takeSnapshot();
+
       setNodes((nodes) =>
         modifyReactFlowNodeProperties(nodes, {
           id: nodeId,

--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -20,10 +20,11 @@ export function LabelUpdaterNode({
   const { setNodes } = useReactFlow();
 
   const [renameLabel, setRenameLabel] = useState(data.label);
+  const inputId = `renameInput-${id}`;
 
   // Select the input element on mount.
   useEffect(() => {
-    const input = document.getElementById("renameInput") as HTMLInputElement | null;
+    const input = document.getElementById(inputId) as HTMLInputElement | null;
 
     // Have to do this with a bit of a delay to
     // ensure it works when triggered via navbar.
@@ -58,7 +59,7 @@ export function LabelUpdaterNode({
       <Row mainAxisAlignment="center" crossAxisAlignment="center" height="100%" px={2}>
         <Input
           onBlur={cancel}
-          id="renameInput"
+          id={inputId}
           value={renameLabel}
           onChange={(e: any) => setRenameLabel(e.target.value)}
           onKeyDown={(e) =>

--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -29,7 +29,7 @@ export function LabelUpdaterNode({
 
     // Have to do this with a bit of a delay to
     // ensure it works when triggered via navbar.
-    setTimeout(() => input?.select(), 0);
+    setTimeout(() => input?.select(), 50);
   }, []);
 
   const cancel = () => {

--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -28,7 +28,7 @@ export function LabelUpdaterNode({
 
     // Have to do this with a bit of a delay to
     // ensure it works when triggered via navbar.
-    setTimeout(() => input?.select(), 50);
+    setTimeout(() => input?.select(), 0);
   }, []);
 
   const cancel = () => {

--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -20,6 +20,7 @@ export function LabelUpdaterNode({
   const { setNodes } = useReactFlow();
 
   const [renameLabel, setRenameLabel] = useState(data.label);
+
   const inputId = `renameInput-${id}`;
 
   // Select the input element on mount.

--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -61,7 +61,9 @@ export function LabelUpdaterNode({
           id="renameInput"
           value={renameLabel}
           onChange={(e: any) => setRenameLabel(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && submit()}
+          onKeyDown={(e) =>
+            e.key === "Enter" ? submit() : e.key === "Escape" && cancel()
+          }
           className="nodrag" // https://reactflow.dev/docs/api/nodes/custom-nodes/#prevent-dragging--selecting
           textAlign="center"
           size="xs"


### PR DESCRIPTION
## Motivation

Quick PR that fixes a few bugs and small improvements related to rename logic introduced in #11 

- take snapshot only if rename logic applies
- prevent multiple with non-unique ids to break intended behaviour (for example if while a node is edited another one is selected and renamed via keyboard without deselecting the first one, a bunch of issues arise)
- allow exit renaming via escape key
- reduce timeout workaround in `LabelUpdaterNode` to 0ms