### PR TITLE
feat: auto generate labels for User and GPT nodes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -82,7 +82,7 @@ import {
   TOAST_CONFIG,
   UNDEFINED_RESPONSE_STRING,
   STREAM_CANCELED_ERROR_MESSAGE,
-  MAX_AUTOLABEL_LENGTH,
+  MAX_AUTOLABEL_CHARS,
 } from "../utils/constants";
 import { mod } from "../utils/mod";
 import { BigButton } from "./utils/BigButton";
@@ -533,9 +533,9 @@ function App() {
     // Generate auto-label for parentNode, if unset
     if (parentNode.data.label === parentNode.data.fluxNodeType) {
       const autoLabel =
-        parentNode.data.text.length > MAX_AUTOLABEL_LENGTH
+        parentNode.data.text.length > MAX_AUTOLABEL_CHARS
           ? parentNode.data.text
-              .slice(0, MAX_AUTOLABEL_LENGTH)
+              .slice(0, MAX_AUTOLABEL_CHARS)
               .split(" ")
               .slice(0, -1)
               .join(" ") + " ..."

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -323,7 +323,7 @@ function App() {
           data: {
             ...childNode.data,
             text: "",
-            label: displayNameFromFluxNodeType(FluxNodeType.GPT),
+            label: childNode.data.label ?? displayNameFromFluxNodeType(FluxNodeType.GPT),
             fluxNodeType: FluxNodeType.GPT,
             streamId,
           },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,7 +58,6 @@ import {
   addUserNodeLinkedToASystemNode,
   getConnectionAllowed,
   setFluxNodeStreamId,
-  modifyFluxNodeLabel,
 } from "../utils/fluxNode";
 import {
   FluxNodeData,
@@ -82,7 +81,6 @@ import {
   TOAST_CONFIG,
   UNDEFINED_RESPONSE_STRING,
   STREAM_CANCELED_ERROR_MESSAGE,
-  MAX_AUTOLABEL_CHARS,
 } from "../utils/constants";
 import { mod } from "../utils/mod";
 import { BigButton } from "./utils/BigButton";
@@ -530,24 +528,24 @@ function App() {
       return newEdges;
     });
 
-    // Generate auto-label for parentNode, if unset
-    if (parentNode.data.label === parentNode.data.fluxNodeType) {
-      const autoLabel =
-        parentNode.data.text.length > MAX_AUTOLABEL_CHARS
-          ? parentNode.data.text
-              .slice(0, MAX_AUTOLABEL_CHARS)
-              .split(" ")
-              .slice(0, -1)
-              .join(" ") + " ..."
-          : parentNode.data.text;
+    // // Generate auto-label for parentNode, if unset
+    // if (parentNode.data.label === parentNode.data.fluxNodeType) {
+    //   const autoLabel =
+    //     parentNode.data.text.length > MAX_AUTOLABEL_CHARS
+    //       ? parentNode.data.text
+    //           .slice(0, MAX_AUTOLABEL_CHARS)
+    //           .split(" ")
+    //           .slice(0, -1)
+    //           .join(" ") + " ..."
+    //       : parentNode.data.text;
 
-      setNodes((nodes) =>
-        modifyFluxNodeLabel(nodes, {
-          id: parentNode.id,
-          label: autoLabel,
-        })
-      );
-    }
+    //   setNodes((nodes) =>
+    //     modifyFluxNodeLabel(nodes, {
+    //       id: parentNode.id,
+    //       label: autoLabel,
+    //     })
+    //   );
+    // }
 
     autoZoomIfNecessary();
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -528,25 +528,6 @@ function App() {
       return newEdges;
     });
 
-    // // Generate auto-label for parentNode, if unset
-    // if (parentNode.data.label === parentNode.data.fluxNodeType) {
-    //   const autoLabel =
-    //     parentNode.data.text.length > MAX_AUTOLABEL_CHARS
-    //       ? parentNode.data.text
-    //           .slice(0, MAX_AUTOLABEL_CHARS)
-    //           .split(" ")
-    //           .slice(0, -1)
-    //           .join(" ") + " ..."
-    //       : parentNode.data.text;
-
-    //   setNodes((nodes) =>
-    //     modifyFluxNodeLabel(nodes, {
-    //       id: parentNode.id,
-    //       label: autoLabel,
-    //     })
-    //   );
-    // }
-
     autoZoomIfNecessary();
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -531,7 +531,6 @@ function App() {
     });
 
     // Generate auto-label for parentNode, if unset
-
     if (parentNode.data.label === parentNode.data.fluxNodeType) {
       const autoLabel =
         parentNode.data.text.length > MAX_AUTOLABEL_LENGTH

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -61,5 +61,5 @@ export const CODE_BLOCK_LANGUAGE_DETECT_REGEX = /^```[a-zA-Z0-9-]*$/m;
 export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
 export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
 
-// Lucky number to almost always make auto-label text stay in two lines
-export const MAX_AUTOLABEL_CHARS = 32;
+// Magic number to almost always make auto-label text stay in two lines
+export const MAX_AUTOLABEL_CHARS = 34;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -60,3 +60,6 @@ export const CODE_BLOCK_LANGUAGE_DETECT_REGEX = /^```[a-zA-Z0-9-]*$/m;
 
 export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
 export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
+
+// Lucky number to almost always make auto-label text stay in two lines
+export const MAX_AUTOLABEL_LENGTH = 32;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -62,4 +62,4 @@ export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
 export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
 
 // Lucky number to almost always make auto-label text stay in two lines
-export const MAX_AUTOLABEL_LENGTH = 32;
+export const MAX_AUTOLABEL_CHARS = 32;

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -151,12 +151,6 @@ export function modifyFluxNodeText(
       };
 
       copy.data.fluxNodeType = FluxNodeType.TweakedGPT;
-
-      // TODO: This shouldn't apply anymore, as a node now never arrives here being named `FluxNodeType.GPT` due to auto-label. Should we remove the logic, or adapt it?
-      copy.data.label =
-        copy.data.label != displayNameFromFluxNodeType(FluxNodeType.GPT)
-          ? copy.data.label // Preserve custom labels if necessary.
-          : displayNameFromFluxNodeType(FluxNodeType.TweakedGPT);
     }
 
     // Generate auto label based on prompt text

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -1,7 +1,7 @@
 import { Node, Edge } from "reactflow";
 
 import {
-  MAX_AUTOLABEL_LENGTH,
+  MAX_AUTOLABEL_CHARS,
   NEW_TREE_X_OFFSET,
   OVERLAP_RANDOMNESS_MAX,
   STALE_STREAM_ERROR_MESSAGE,
@@ -214,7 +214,7 @@ export function appendTextToFluxNodeAsGPT(
 
     // If label hasn't reached max length or it's a new prompt, set from text.
     // Once label reaches max length, truncate it.
-    if (copy.data.label.length < MAX_AUTOLABEL_LENGTH || isNewPrompt) {
+    if (copy.data.label.length < MAX_AUTOLABEL_CHARS || isNewPrompt) {
       copy.data.label = copy.data.text;
     } else if (!isTruncated) {
       copy.data.label += " ...";

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -224,7 +224,7 @@ export function appendTextToFluxNodeAsGPT(
     // Once label reaches max length, truncate it.
     if (copy.data.label.length < MAX_AUTOLABEL_CHARS || isFirstToken) {
       copy.data.label = copy.data.text;
-    } else if (copy.data.label.endsWith(" ...")) {
+    } else if (!copy.data.label.endsWith(" ...")) {
       copy.data.label += " ...";
     }
 

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -201,7 +201,7 @@ export function appendTextToFluxNodeAsGPT(
     // To reduce complexity we assume auto-labels either end with " ..." or are equal to the generated text.
     const isTruncated = copy.data.label.endsWith(" ...");
     const isPreviousAutoLabel = isTruncated || copy.data.label === copy.data.text;
-    const isNewPrompt = copy.data.text.length === 0;
+    const isFirstToken = copy.data.text.length === 0;
 
     copy.data.text += text;
 
@@ -214,7 +214,7 @@ export function appendTextToFluxNodeAsGPT(
 
     // If label hasn't reached max length or it's a new prompt, set from text.
     // Once label reaches max length, truncate it.
-    if (copy.data.label.length < MAX_AUTOLABEL_CHARS || isNewPrompt) {
+    if (copy.data.label.length < MAX_AUTOLABEL_CHARS || isFirstToken) {
       copy.data.label = copy.data.text;
     } else if (!isTruncated) {
       copy.data.label += " ...";

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -152,7 +152,9 @@ export function modifyFluxNodeText(
 
     // Generate auto label based on prompt text, and preserve custom label
     if (!copy.data.hasCustomlabel) {
-      copy.data.label = formatAutoLabel(copy.data.text);
+      copy.data.label = copy.data.text
+        ? formatAutoLabel(copy.data.text)
+        : displayNameFromFluxNodeType(copy.data.fluxNodeType);
     }
 
     return copy;

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -148,10 +148,34 @@ export function modifyFluxNodeText(
       };
 
       copy.data.fluxNodeType = FluxNodeType.TweakedGPT;
+
+      // TODO: This shouldn't apply anymore, as a node now never arrives here being named `FluxNodeType.GPT` due to auto-label. Should we remove the logic, or adapt it?
       copy.data.label =
         copy.data.label != displayNameFromFluxNodeType(FluxNodeType.GPT)
           ? copy.data.label // Preserve custom labels if necessary.
           : displayNameFromFluxNodeType(FluxNodeType.TweakedGPT);
+    }
+
+    // TODO: How to differentiate between custom label, when prompt is not changed at the end of the label?
+    const parseLength =
+      copy.data.text.length > MAX_AUTOLABEL_CHARS
+        ? MAX_AUTOLABEL_CHARS
+        : copy.data.text.length - 1; // account for new character being added
+
+    if (
+      copy.data.label.startsWith(copy.data.text.slice(0, parseLength)) ||
+      copy.data.label === displayNameFromFluxNodeType(copy.data.fluxNodeType)
+    ) {
+      const autoLabel =
+        copy.data.text.length > MAX_AUTOLABEL_CHARS
+          ? copy.data.text
+              .slice(0, MAX_AUTOLABEL_CHARS)
+              .split(" ")
+              .slice(0, -1)
+              .join(" ") + " ..."
+          : copy.data.text;
+
+      copy.data.label = autoLabel;
     }
 
     return copy;

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -10,6 +10,7 @@ import {
 import { FluxNodeType, FluxNodeData, ReactFlowNodeTypes } from "./types";
 import { getFluxNodeTypeColor } from "./color";
 import { generateNodeId } from "./nodeId";
+import { formatAutoLabel } from "./prompt";
 
 /*//////////////////////////////////////////////////////////////
                          CONSTRUCTORS
@@ -137,6 +138,8 @@ export function modifyFluxNodeText(
 
     const copy = { ...node, data: { ...node.data } };
 
+    const initText = copy.data.text;
+
     copy.data.text = text;
 
     // If the node's fluxNodeType is GPT and we're changing
@@ -156,26 +159,12 @@ export function modifyFluxNodeText(
           : displayNameFromFluxNodeType(FluxNodeType.TweakedGPT);
     }
 
-    // TODO: How to differentiate between custom label, when prompt is not changed at the end of the label?
-    const parseLength =
-      copy.data.text.length > MAX_AUTOLABEL_CHARS
-        ? MAX_AUTOLABEL_CHARS
-        : copy.data.text.length - 1; // account for new character being added
-
+    // Generate auto label based on prompt text
     if (
-      copy.data.label.startsWith(copy.data.text.slice(0, parseLength)) ||
+      copy.data.label.startsWith(formatAutoLabel(initText)) ||
       copy.data.label === displayNameFromFluxNodeType(copy.data.fluxNodeType)
     ) {
-      const autoLabel =
-        copy.data.text.length > MAX_AUTOLABEL_CHARS
-          ? copy.data.text
-              .slice(0, MAX_AUTOLABEL_CHARS)
-              .split(" ")
-              .slice(0, -1)
-              .join(" ") + " ..."
-          : copy.data.text;
-
-      copy.data.label = autoLabel;
+      copy.data.label = formatAutoLabel(copy.data.text);
     }
 
     return copy;

--- a/src/utils/fluxNode.ts
+++ b/src/utils/fluxNode.ts
@@ -1,7 +1,6 @@
 import { Node, Edge } from "reactflow";
 
 import {
-  MAX_AUTOLABEL_CHARS,
   NEW_TREE_X_OFFSET,
   OVERLAP_RANDOMNESS_MAX,
   STALE_STREAM_ERROR_MESSAGE,
@@ -151,13 +150,9 @@ export function modifyFluxNodeText(
       copy.data.fluxNodeType = FluxNodeType.TweakedGPT;
     }
 
-    // Generate auto label based on prompt text
-    if (
-      !copy.data.hasCustomlabel ||
-      copy.data.label === displayNameFromFluxNodeType(copy.data.fluxNodeType)
-    ) {
+    // Generate auto label based on prompt text, and preserve custom label
+    if (!copy.data.hasCustomlabel) {
       copy.data.label = formatAutoLabel(copy.data.text);
-      copy.data.hasCustomlabel = false;
     }
 
     return copy;
@@ -214,18 +209,12 @@ export function appendTextToFluxNodeAsGPT(
     copy.data.text += text;
 
     // Preserve custom labels
-    if (
-      copy.data.hasCustomlabel ||
-      copy.data.label === displayNameFromFluxNodeType(FluxNodeType.GPT)
-    )
-      return copy;
+    if (copy.data.hasCustomlabel) return copy;
 
     // If label hasn't reached max length or it's a new prompt, set from text.
     // Once label reaches max length, truncate it.
-    if (copy.data.label.length < MAX_AUTOLABEL_CHARS || isFirstToken) {
-      copy.data.label = copy.data.text;
-    } else if (!copy.data.label.endsWith(" ...")) {
-      copy.data.label += " ...";
+    if (!copy.data.label.endsWith(" ...") || isFirstToken) {
+      copy.data.label = formatAutoLabel(copy.data.text);
     }
 
     return copy;

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -73,8 +73,24 @@ export function promptFromLineage(
   return prompt;
 }
 
-export function formatAutoLabel(text: string) {
+export function formatAutoLabel(unformattedText: string) {
+  const text = removeInvalidChars(unformattedText);
+
   return text.length > MAX_AUTOLABEL_CHARS
     ? text.slice(0, MAX_AUTOLABEL_CHARS).split(" ").slice(0, -1).join(" ") + " ..."
     : text;
+}
+
+function removeInvalidChars(text: string) {
+  // The regular expression pattern:
+  // ^: not
+  // a-zA-Z0-9: letters and numbers
+  // .,?!: common punctuation marks
+  // \s: whitespace characters (space, tab, newline, etc.)
+  const regex = /[^a-zA-Z0-9.,?!-\s]+/g;
+
+  // Replace invalid characters with an empty string
+  const cleanedStr = text.replaceAll("\n", " ").replace(regex, "");
+
+  return cleanedStr;
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -3,6 +3,7 @@ import { Node } from "reactflow";
 import { ChatCompletionRequestMessage } from "openai-streams";
 
 import { FluxNodeData, FluxNodeType, Settings } from "./types";
+import { MAX_AUTOLABEL_CHARS } from "./constants";
 
 export function messagesFromLineage(
   lineage: Node<FluxNodeData>[],
@@ -70,4 +71,10 @@ export function promptFromLineage(
   console.log(prompt);
 
   return prompt;
+}
+
+export function formatAutoLabel(text: string) {
+  return text.length > MAX_AUTOLABEL_CHARS
+    ? text.slice(0, MAX_AUTOLABEL_CHARS).split(" ").slice(0, -1).join(" ") + " ..."
+    : text;
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -73,12 +73,13 @@ export function promptFromLineage(
   return prompt;
 }
 
-export function formatAutoLabel(unformattedText: string) {
-  const text = removeInvalidChars(unformattedText);
+export function formatAutoLabel(text: string) {
+  const formattedText = removeInvalidChars(text);
 
-  return text.length > MAX_AUTOLABEL_CHARS
-    ? text.slice(0, MAX_AUTOLABEL_CHARS).split(" ").slice(0, -1).join(" ") + " ..."
-    : text;
+  return formattedText.length > MAX_AUTOLABEL_CHARS
+    ? formattedText.slice(0, MAX_AUTOLABEL_CHARS).split(" ").slice(0, -1).join(" ") +
+        " ..."
+    : formattedText;
 }
 
 function removeInvalidChars(text: string) {
@@ -87,9 +88,9 @@ function removeInvalidChars(text: string) {
   // a-zA-Z0-9: letters and numbers
   // .,?!: common punctuation marks
   // \s: whitespace characters (space, tab, newline, etc.)
-  const regex = /[^a-zA-Z0-9.,?!-\s]+/g;
+  const regex = /[^a-zA-Z0-9.,'?!-\s]+/g;
 
-  // Replace invalid characters with an empty string
+  // Replace `\n` with spaces and remove invalid characters
   const cleanedStr = text.replaceAll("\n", " ").replace(regex, "");
 
   return cleanedStr;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,6 +7,7 @@ export type FluxNodeData = {
   fluxNodeType: FluxNodeType;
   text: string;
   streamId?: string;
+  hasCustomlabel?: boolean;
 };
 
 export enum FluxNodeType {


### PR DESCRIPTION
## Motivation

Closes #33.

## Solution

- Auto-label all nodes during generation, as well as when prompt is edited. 
- Truncate once length is over a threshold.
- Prevent auto-label generation if node has been manually renamed by user

https://user-images.githubusercontent.com/39241410/229579041-b80a1fa7-5166-4a8c-9c9a-8e0af728b7ea.mov


### Notes

ngl it's pretty sick seeing auto-generated label streaming

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari
