### PR TITLE
feat: add tooltip to nodes when being renamed

### DIFF
--- a/src/components/nodes/LabelUpdaterNode.tsx
+++ b/src/components/nodes/LabelUpdaterNode.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Box, Input } from "@chakra-ui/react";
+import { Box, Input, Tooltip } from "@chakra-ui/react";
 
 import { Handle, Position, useReactFlow } from "reactflow";
 
@@ -54,25 +54,26 @@ export function LabelUpdaterNode({
   };
 
   return (
-    <Box width="150px" height="38px">
-      <Handle type="target" position={Position.Top} isConnectable={isConnectable} />
+    <Tooltip label="⏎">
+      <Box width="150px" height="38px">
+        <Handle type="target" position={Position.Top} isConnectable={isConnectable} />
 
-      <Row mainAxisAlignment="center" crossAxisAlignment="center" height="100%" px={2}>
-        <Input
-          onBlur={cancel}
-          id={inputId}
-          value={renameLabel}
-          onChange={(e: any) => setRenameLabel(e.target.value)}
-          onKeyDown={(e) =>
-            e.key === "Enter" ? submit() : e.key === "Escape" && cancel()
-          }
-          className="nodrag" // https://reactflow.dev/docs/api/nodes/custom-nodes/#prevent-dragging--selecting
-          textAlign="center"
-          size="xs"
-          // px={6}
-        />
+        <Row mainAxisAlignment="center" crossAxisAlignment="center" height="100%" px={2}>
+          <Input
+            onBlur={cancel}
+            id={inputId}
+            value={renameLabel}
+            onChange={(e: any) => setRenameLabel(e.target.value)}
+            onKeyDown={(e) =>
+              e.key === "Enter" ? submit() : e.key === "Escape" && cancel()
+            }
+            className="nodrag" // https://reactflow.dev/docs/api/nodes/custom-nodes/#prevent-dragging--selecting
+            textAlign="center"
+            size="xs"
+            // px={6}
+          />
 
-        {/* <Row
+          {/* <Row
           mainAxisAlignment="center"
           crossAxisAlignment="center"
           position="absolute"
@@ -89,9 +90,10 @@ export function LabelUpdaterNode({
             onClick={cancel}
           />
         </Row> */}
-      </Row>
+        </Row>
 
-      <Handle type="source" position={Position.Bottom} isConnectable={isConnectable} />
-    </Box>
+        <Handle type="source" position={Position.Bottom} isConnectable={isConnectable} />
+      </Box>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Motivation

The user might be confused when trying to save when renaming a node, due to the lack of UI elements.

## Solution

Added a tooltip that hints at pressing return to save

<img width="284" alt="Screenshot 2023-04-03 at 18 55 59" src="https://user-images.githubusercontent.com/39241410/229576932-1cc00771-027b-4643-9bb1-2f202850e91c.png">

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari
