### PR TITLE
feat: add panning key for mouse users

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1058,7 +1058,7 @@ function App() {
                 onSelectionDragStop={autoZoomIfNecessary}
                 selectionKeyCode={null}
                 multiSelectionKeyCode="Shift"
-                panActivationKeyCode={null}
+                panActivationKeyCode="Shift"
                 deleteKeyCode={null}
                 panOnDrag={false}
                 selectionOnDrag={true}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

## Motivation

#36 - Making paning around the React Flow container possible for mouse users.

## Solution

Simply changing a prop allows for paning. The 'Shift' panActivationKeyCode does not interfere with the 'Shift' multiSelectionKeyCode since they are two different interactions. 

I chose 'Shift' instead of 'Space' (even though space is more intuitive/figma-like) because 'Space' leads to accidental inputs on nodes which isn't great UX. This requires the user to have to click out once before paning if they want to avoid an input, whereas the user can easily switch without clicking out first if the keybind is 'Shift' instead.

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [x] Tested in Chrome
- [x] Tested in Safari
