### PR TITLE
feat: persists chat window size on reload

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1029,6 +1029,7 @@ function App() {
             onResizeStop={(_, __, ref) => {
               setSavedChatSize(ref.style.width);
               autoZoomIfNecessary();
+              if (MIXPANEL_TOKEN) mixpanel.track("Resized chat window");
             }}
           >
             <Column

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1012,7 +1012,7 @@ function App() {
             maxWidth="75%"
             minWidth="15%"
             defaultSize={{
-              // defaults to the previously used chat size if it exists.
+              // Defaults to the previously used chat size if it exists.
               width: savedChatSize || "50%",
               height: "auto",
             }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -81,6 +81,7 @@ import {
   TOAST_CONFIG,
   UNDEFINED_RESPONSE_STRING,
   STREAM_CANCELED_ERROR_MESSAGE,
+  SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY,
 } from "../utils/constants";
 import { mod } from "../utils/mod";
 import { BigButton } from "./utils/BigButton";
@@ -908,6 +909,14 @@ function App() {
   useDebouncedWindowResize(autoZoomIfNecessary, 100);
 
   /*//////////////////////////////////////////////////////////////
+                        CHAT RESIZE LOGIC
+  //////////////////////////////////////////////////////////////*/
+
+  const [savedChatSize, setSavedChatSize] = useLocalStorage<string>(
+    SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY
+  );
+
+  /*//////////////////////////////////////////////////////////////
                           HOTKEYS LOGIC
   //////////////////////////////////////////////////////////////*/
 
@@ -972,7 +981,8 @@ function App() {
             maxWidth="75%"
             minWidth="15%"
             defaultSize={{
-              width: "50%",
+              // defaults to the previously used chat size if it exists.
+              width: savedChatSize || "50%",
               height: "auto",
             }}
             enable={{
@@ -985,7 +995,10 @@ function App() {
               bottomLeft: false,
               topLeft: false,
             }}
-            onResizeStop={autoZoomIfNecessary}
+            onResizeStop={(_, __, ref) => {
+              setSavedChatSize(ref.style.width);
+              autoZoomIfNecessary();
+            }}
           >
             <Column
               mainAxisAlignment="center"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1029,6 +1029,7 @@ function App() {
             onResizeStop={(_, __, ref) => {
               setSavedChatSize(ref.style.width);
               autoZoomIfNecessary();
+
               if (MIXPANEL_TOKEN) mixpanel.track("Resized chat window");
             }}
           >

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,7 @@ export const OVERLAP_RANDOMNESS_MAX = 20;
 export const API_KEY_LOCAL_STORAGE_KEY = "FLUX_OPENAI_API_KEY";
 export const REACT_FLOW_LOCAL_STORAGE_KEY = "FLUX_REACT_FLOW_DATA";
 export const MODEL_SETTINGS_LOCAL_STORAGE_KEY = "FLUX_MODEL_SETTINGS";
+export const SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY = "FLUX_SAVED_CHAT_SIZE";
 
 export const NEW_TREE_CONTENT_QUERY_PARAM = "newTreeWith";
 
@@ -60,8 +61,6 @@ export const CODE_BLOCK_LANGUAGE_DETECT_REGEX = /^```[a-zA-Z0-9-]*$/m;
 
 export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
 export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
-
-export const SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY = "FLUX_SAVED_CHAT_SIZE";
 
 // Magic number to almost always make auto-label text stay in two lines.
 export const MAX_AUTOLABEL_CHARS = 32;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -62,5 +62,6 @@ export const STREAM_CANCELED_ERROR_MESSAGE = "STREAM_CANCELED";
 export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
 
 export const SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY = "FLUX_SAVED_CHAT_SIZE";
+
 // Magic number to almost always make auto-label text stay in two lines.
 export const MAX_AUTOLABEL_CHARS = 32;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -63,3 +63,5 @@ export const STALE_STREAM_ERROR_MESSAGE = "STALE_STREAM";
 
 // Magic number to almost always make auto-label text stay in two lines
 export const MAX_AUTOLABEL_CHARS = 34;
+
+export const SAVED_CHAT_SIZE_LOCAL_STORAGE_KEY = "FLUX_SAVED_CHAT_SIZE";


### PR DESCRIPTION
## Motivation

Issue #47. It would be nice to persist the chat size on revisits for consistency.

## Solution

Utilizing the handy useLocalStorage util, we can save and update the chat window size whenever it's changed. If the key doesn't exist in localStorage, we default to the original 50% width.

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari
