### PR TITLE
fix: markdown styling improvements, list item newline fix

### DIFF
--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -2,7 +2,16 @@ import React, { useState, useEffect, memo, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import "highlight.js/styles/atom-one-light.css";
 import rehypeHighlight from "rehype-highlight";
-import { Button, Box, Code, Text, useTheme, List, ListItem, Stack } from "@chakra-ui/react";
+import {
+  Button,
+  Box,
+  Code,
+  Text,
+  useTheme,
+  List,
+  ListItem,
+  Stack,
+} from "@chakra-ui/react";
 import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
 import { copySnippetToClipboard } from "../../utils/clipboard";
@@ -70,28 +79,47 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
           [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
         ]}
         components={{
-          ul({children}) {
-            return <List styleType="disc" ml={5} h="fit-content">{children}</List>;
+          ul({ children }) {
+            return (
+              <List styleType="disc" h="fit-content">
+                {children}
+              </List>
+            );
           },
-          ol({children}) {
-            return <List styleType="decimal" ml={5} h="fit-content">{children}</List>;
+          ol({ children }) {
+            return (
+              <List styleType="decimal" h="fit-content" pl="25px">
+                {children}
+              </List>
+            );
           },
           li({ children }) {
+            // i'm not a huge fan of this but it works. seems there's a leading newline in the children sometimes?
+            // not a good final solution yet because it strips extra newlines that might still want to be included.
+            let isLeadingNewline = true;
+            const filteredChildren = children.filter((child: ReactNode) => {
+              const isBreakingNewline =
+                isLeadingNewline && typeof child === "string" && child.trim() === "";
+
+              isLeadingNewline = false;
+
+              return !isBreakingNewline;
+            });
+
             return (
-              <ListItem lineHeight={1.2} mb="0px" ml={5} h="fit-content">
-                {children}
+              <ListItem as="li" lineHeight={1.2} mb="0px">
+                {filteredChildren}
               </ListItem>
             );
           },
           blockquote({ children }) {
             return (
               <Box
-                borderLeft="5px solid #eee"
+                borderLeft="10px solid #eee"
                 backgroundColor="#f5f5f5"
                 borderRadius="0.25rem"
                 padding="0.5rem"
                 margin="1rem 0"
-                height="fit-content"
               >
                 {children}
               </Box>
@@ -108,16 +136,16 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
                 crossAxisAlignment="center"
               >
                 <TitleBar language={match?.[1]} code={children} />
-                  <Code
-                    width="100%"
-                    padding={!match?.[1] ? "10px" : 0} // When no language is specified, inconsistent padding is applied. This fixes that.
-                    className={className}
-                    {...props}
-                    backgroundColor="white"
-                    style={{ whiteSpace: "pre-wrap" }}
-                  >
-                    {children}
-                  </Code>
+                <Code
+                  width="100%"
+                  padding={!match?.[1] ? "10px" : 0} // When no language is specified, inconsistent padding is applied. This fixes that.
+                  className={className}
+                  {...props}
+                  backgroundColor="white"
+                  style={{ whiteSpace: "pre-wrap" }}
+                >
+                  {children}
+                </Code>
               </Column>
             ) : (
               <Code

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, memo, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import "highlight.js/styles/atom-one-light.css";
 import rehypeHighlight from "rehype-highlight";
-import { Button, Box, Code, Text, useTheme } from "@chakra-ui/react";
+import { Button, Box, Code, Text, useTheme, List, ListItem, Stack } from "@chakra-ui/react";
 import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
 import { copySnippetToClipboard } from "../../utils/clipboard";
@@ -16,7 +16,7 @@ const TitleBar = ({ language, code }: { language?: string; code: ReactNode[] }) 
   return (
     <Row
       mainAxisAlignment="flex-start"
-      crossAxisAlignment="stretch"
+      crossAxisAlignment="center"
       expand
       justifyContent="space-between"
       alignItems="center"
@@ -64,12 +64,39 @@ const CopyCodeButton = ({ code }: { code: ReactNode[] }) => {
 
 export const Markdown = memo(function Markdown({ text }: { text: string }) {
   return (
-    <Box className="markdown-wrapper" width="100%" wordBreak="break-word">
+    <Stack className="markdown-wrapper" width="100%" wordBreak="break-word">
       <ReactMarkdown
         rehypePlugins={[
           [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
         ]}
         components={{
+          ul({children}) {
+            return <List styleType="disc" ml={5} h="fit-content">{children}</List>;
+          },
+          ol({children}) {
+            return <List styleType="decimal" ml={5} h="fit-content">{children}</List>;
+          },
+          li({ children }) {
+            return (
+              <ListItem lineHeight={1.2} mb="0px" ml={5} h="fit-content">
+                {children}
+              </ListItem>
+            );
+          },
+          blockquote({ children }) {
+            return (
+              <Box
+                borderLeft="5px solid #eee"
+                backgroundColor="#f5f5f5"
+                borderRadius="0.25rem"
+                padding="0.5rem"
+                margin="1rem 0"
+                height="fit-content"
+              >
+                {children}
+              </Box>
+            );
+          },
           code({ node, inline, className, children, style, ...props }) {
             const match = /language-(\w+)/.exec(className || "");
 
@@ -81,16 +108,16 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
                 crossAxisAlignment="center"
               >
                 <TitleBar language={match?.[1]} code={children} />
-                <Code
-                  width="100%"
-                  padding={!match?.[1] ? "10px" : 0} // When no language is specified, inconsistent padding is applied. This fixes that.
-                  className={className}
-                  {...props}
-                  backgroundColor="white"
-                  style={{ whiteSpace: "pre-wrap" }}
-                >
-                  {children}
-                </Code>
+                  <Code
+                    width="100%"
+                    padding={!match?.[1] ? "10px" : 0} // When no language is specified, inconsistent padding is applied. This fixes that.
+                    className={className}
+                    {...props}
+                    backgroundColor="white"
+                    style={{ whiteSpace: "pre-wrap" }}
+                  >
+                    {children}
+                  </Code>
               </Column>
             ) : (
               <Code
@@ -107,7 +134,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
       >
         {text}
       </ReactMarkdown>
-    </Box>
+    </Stack>
   );
 });
 

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -96,10 +96,8 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
           },
           li({ children }) {
             return (
-              <ListItem as="li" lineHeight={1.2} mb="0px" ml="20px">
-                <Flex>
+              <ListItem as="li" mb="0px" ml="20px">
                   {children}
-                </Flex>
               </ListItem>
             );
           },

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -11,6 +11,7 @@ import {
   List,
   ListItem,
   Stack,
+  Flex
 } from "@chakra-ui/react";
 import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
@@ -25,7 +26,7 @@ const TitleBar = ({ language, code }: { language?: string; code: ReactNode[] }) 
   return (
     <Row
       mainAxisAlignment="flex-start"
-      crossAxisAlignment="center"
+      crossAxisAlignment="stretch"
       expand
       justifyContent="space-between"
       alignItems="center"
@@ -88,27 +89,17 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
           },
           ol({ children }) {
             return (
-              <List styleType="decimal" h="fit-content" pl="25px">
+              <List styleType="decimal" h="fit-content">
                 {children}
               </List>
             );
           },
           li({ children }) {
-            // i'm not a huge fan of this but it works. seems there's a leading newline in the children sometimes?
-            // not a good final solution yet because it strips extra newlines that might still want to be included.
-            let isLeadingNewline = true;
-            const filteredChildren = children.filter((child: ReactNode) => {
-              const isBreakingNewline =
-                isLeadingNewline && typeof child === "string" && child.trim() === "";
-
-              isLeadingNewline = false;
-
-              return !isBreakingNewline;
-            });
-
             return (
-              <ListItem as="li" lineHeight={1.2} mb="0px">
-                {filteredChildren}
+              <ListItem as="li" lineHeight={1.2} mb="0px" ml="20px">
+                <Flex>
+                  {children}
+                </Flex>
               </ListItem>
             );
           },

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -112,7 +112,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
           blockquote({ children }) {
             return (
               <Box
-                borderLeft="10px solid #eee"
+                borderLeft="5px solid #F5F5F5"
                 backgroundColor="white"
                 borderRadius="0.25rem"
                 padding="0.5rem"

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -11,7 +11,6 @@ import {
   List,
   ListItem,
   Stack,
-  Flex
 } from "@chakra-ui/react";
 import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -113,7 +113,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
             return (
               <Box
                 borderLeft="10px solid #eee"
-                backgroundColor="#f5f5f5"
+                backgroundColor="white"
                 borderRadius="0.25rem"
                 padding="0.5rem"
                 margin="1rem 0"

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -95,9 +95,18 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
             );
           },
           li({ children }) {
+            let isLeadingNewline = true;
+            const filteredChildren = children.filter((child: ReactNode) => {
+              const isBreakingNewline =
+                isLeadingNewline && typeof child === "string" && child.trim() === "";
+
+              isLeadingNewline = false;
+
+              return !isBreakingNewline;
+            });
             return (
               <ListItem as="li" mb="0px" ml="20px">
-                  {children}
+                  {filteredChildren}
               </ListItem>
             );
           },

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -2,16 +2,7 @@ import React, { useState, useEffect, memo, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import "highlight.js/styles/atom-one-light.css";
 import rehypeHighlight from "rehype-highlight";
-import {
-  Button,
-  Box,
-  Code,
-  Text,
-  useTheme,
-  List,
-  ListItem,
-  Stack,
-} from "@chakra-ui/react";
+import { Button, Box, Code, Text, useTheme, List, ListItem } from "@chakra-ui/react";
 import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
 import { copySnippetToClipboard } from "../../utils/clipboard";
@@ -73,7 +64,7 @@ const CopyCodeButton = ({ code }: { code: ReactNode[] }) => {
 
 export const Markdown = memo(function Markdown({ text }: { text: string }) {
   return (
-    <Stack className="markdown-wrapper" width="100%" wordBreak="break-word">
+    <Box className="markdown-wrapper" width="100%" wordBreak="break-word">
       <ReactMarkdown
         rehypePlugins={[
           [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
@@ -150,7 +141,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
       >
         {text}
       </ReactMarkdown>
-    </Stack>
+    </Box>
   );
 });
 

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -105,7 +105,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
             });
             return (
               <ListItem as="li" mb="0px" ml="20px">
-                  {filteredChildren}
+                {filteredChildren}
               </ListItem>
             );
           },

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -94,31 +94,22 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
             );
           },
           li({ children }) {
-            let isLeadingNewline = true;
-            const filteredChildren = children.filter((child: ReactNode) => {
-              const isBreakingNewline =
-                isLeadingNewline && typeof child === "string" && child.trim() === "";
-
-              isLeadingNewline = false;
-
-              return !isBreakingNewline;
-            });
             return (
               <ListItem as="li" mb="0px" ml="20px">
-                {filteredChildren}
+                {children?.filter(
+                  (child: ReactNode) =>
+                    !(typeof child === "string" && child.trim() === "")
+                )}
               </ListItem>
             );
           },
           blockquote({ children }) {
             return (
-              <Box
-                borderLeft="8px solid #F5F5F5"
-                backgroundColor="white"
-                borderRadius="0.25rem"
-                padding="0.5rem"
-                margin="1rem 0"
-              >
-                {children}
+              <Box borderLeft="2px solid currentcolor" pl="20px">
+                {children?.filter(
+                  (child: ReactNode) =>
+                    !(typeof child === "string" && child.trim() === "")
+                )}
               </Box>
             );
           },

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -112,7 +112,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
           blockquote({ children }) {
             return (
               <Box
-                borderLeft="5px solid #F5F5F5"
+                borderLeft="8px solid #F5F5F5"
                 backgroundColor="white"
                 borderRadius="0.25rem"
                 padding="0.5rem"

--- a/src/index.css
+++ b/src/index.css
@@ -25,11 +25,6 @@
   margin: revert;
 }
 
-.markdown-wrapper ol,
-.markdown-wrapper ul {
-  margin-left: 20px;
-}
-
 .markdown-wrapper h1 {
   font-size: 2em;
 }


### PR DESCRIPTION
## Motivation

#60 - markdown styling improvements and list element display bug

## Solution

TBD, utilizing chakra components for each element seems to work. still troubleshooting the newline list bug.

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Chakra UI styling and formatting to Markdown components in the app. Notable changes include:

### Detailed summary
- Added Chakra UI `List`, `ListItem`, and `CopyIcon` components
- Adjusted `Markdown` component to include new `List` and `ListItem` components for bullet points and numbered lists
- Adjusted `Markdown` component to include `Box` and `blockquote` components for block quotes
- Adjusted `Markdown` component to filter out empty strings in child elements
- Adjusted `Markdown` component to add left border to code blocks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->