### PR TITLE
nit: tweak red highlight

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 .selected {
-  box-shadow: 0 0 0 2px #4285F4 !important;
+  box-shadow: 0 0 0 2px #E73324 !important;
 }
 
 .react-flow__node {

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 .selected {
-  box-shadow: 0 0 0 2px #4285F4, 0 0 30px 2px #4285F4 !important;
+  box-shadow: 0 0 0 2px #4285F4 !important;
 }
 
 .react-flow__node {

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 .selected {
-  box-shadow: 0px 0px 0px 2px red, 0px 0px 30px 2px red !important;
+  box-shadow: 0 0 0 2px #4285F4, 0 0 30px 2px #4285F4 !important;
 }
 
 .react-flow__node {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

## Motivation

#53 

Red selected highlight doesn't match the rest of the UI.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Changed to #4285F4 a blue color, also the google blue color!

![image](https://user-images.githubusercontent.com/15025146/230701644-58594534-f74c-464a-a65d-1c9c57d63eac.png)


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [X] Tested in Chrome
- [x] Tested in Safari


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the box-shadow styling in `src/index.css` and replaces the red color with `#E73324`.

### Detailed summary
- Replaced red color with `#E73324` in `box-shadow` styling in `src/index.css`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->