### PR TITLE
fix: fixes "[object Object]" copy code button output

### DIFF
--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -136,6 +136,11 @@ const stringifyChildren = (children: ReactNode[]): string => {
           );
         }
 
+        // ignores non-text ReactNodes, fixing [object Object] error.
+        if (typeof currentNode === "object") {
+          return concatenatedText;
+        }
+
         return concatenatedText + String(currentNode || "");
       }, "")
       // react-markdown sometimes includes a newline at the end of the children array.

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -136,7 +136,7 @@ const stringifyChildren = (children: ReactNode[]): string => {
           );
         }
 
-        // ignores non-text ReactNodes, fixing [object Object] error.
+        // Ignore non-text ReactNodes, fixing [object Object] error.
         if (typeof currentNode === "object") {
           return concatenatedText;
         }


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Noticing a small issue where occasionally when utilizing the 'copy code' button, an "[object Object]" string sneaks in. this can be annoying because I have to edit the code once I paste it to remove it, and a beginner might not immediately notice what has happened.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds a return statement if the node type is an object. this results in the [object Object] string being ignored instead of concatenated to the code output.

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [x] Tested in Chrome
- [x] Tested in Safari

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue where non-text ReactNodes caused an error in `Markdown` component. The fix ignores non-text nodes and prevents the error.

### Detailed summary
- Added a check to ignore non-text ReactNodes.
- Returns concatenated text and String(currentNode) as fallback.
- Prevents [object Object] error caused by non-text nodes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->