### PR TITLE
Remove length check for sk-proj keys

### DIFF
--- a/src/utils/apikey.ts
+++ b/src/utils/apikey.ts
@@ -1,3 +1,3 @@
 export function isValidAPIKey(apiKey: string | null) {
-  return (apiKey?.length === 51 && apiKey.startsWith("sk-")) || (apiKey?.length === 56 && apiKey.startsWith("sk-proj-"));
+  return (apiKey?.length === 51 && apiKey.startsWith("sk-")) || (apiKey?.startsWith("sk-proj-"));
 }


### PR DESCRIPTION
## Motivation

Context: https://github.com/paradigmxyz/flux/issues/99

I recently created an OpenAI API key, and it has a length of 164 characters, so the `isValidAPIKey` check doesn't work correctly.

## Solution

Since I couldn't quickly find documentation from OpenAI on acceptable lengths of API keys and since OpenAI is free to change the key length whenever they want, I just removed the length check. I kept the length check for `sk-` keys since I don't know if those are definitely restricted to a certain length.

## Checklist


- [x ] Tested in Chrome
- [ x] Tested in Safari
